### PR TITLE
changes entrypoint of packetrusher and adds image info automation

### DIFF
--- a/images/packetrusher/README.md
+++ b/images/packetrusher/README.md
@@ -7,6 +7,6 @@ To be able to run this image, you have to:
 - Run the container with cap_add=all
 - Run the container with privileged=true
 
-The image uses the basic mode of PacketRusher: 1 gNB and 1 UE.
+The image receives the mode of PacketRusher (ue, multi-ue...) as a command. entrypoint can be seen to understand how it works.
 
 You can change the config file using env variables.

--- a/images/packetrusher/entrypoint.sh
+++ b/images/packetrusher/entrypoint.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+if [ $# -lt 1 ]
+then
+        echo "Usage : $0 [ue | multi-ue -n N]"
+        exit
+fi
+
 if [[ -z "${GNB_NGAP_ADDR}" ]] ; then
     export GNB_NGAP_ADDR=$(ip addr show $GNB_NGAP_DEV | grep -Po 'inet \K[\d.]+')
 fi
@@ -16,4 +22,4 @@ fi
 
 envsubst < config/config.yml > config.yml
 
-./packetrusher --config config.yml ue
+./packetrusher --config config.yml $@

--- a/images/packetrusher/image_info.sh
+++ b/images/packetrusher/image_info.sh
@@ -1,0 +1,3 @@
+IMAGE_TAG=97f9f0c
+#comma separated list of platforms. If empty, image will not be multiarch.
+PLATFORMS=

--- a/images/packetrusher/update_current_tag.sh
+++ b/images/packetrusher/update_current_tag.sh
@@ -1,0 +1,36 @@
+#/bin/bash
+
+REMOTE_REPO_URL="https://api.github.com/repos/HewlettPackard/PacketRusher/commits?sha=main"
+
+GH="https://api.github.*"
+GL="https://gitlab.*"
+
+# Fetch the last version available on the remote repository
+if [[ ${REMOTE_REPO_URL} =~ ${GH} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[0].sha' | sed 's/^\(.\{7\}\).*/\1/' )
+# sed explanation
+# -n dont print anything
+# /v[0-9.]\+/h; every match with "v[0-9.]\+" gets stored on hold
+# $g; replace contents of pattern space with hold space, adds last match as last line to buffer
+# s//\1/; replace pattern, removes everything around version
+# $p only last line is printed
+elif [[ ${REMOTE_REPO_URL} =~ ${GL} ]] ; then
+	CURRENT_TAG=$( curl -sSL ${REMOTE_REPO_URL} | jq -r '.[0].sha' | sed 's/^\(.\{7\}\).*/\1/' )
+else
+	echo "Error Reading URL"
+	exit 1
+fi
+
+# Load IMAGE_TAG
+[[ -f image_info.sh ]] && source image_info.sh || exit 1
+
+
+# Compare CURRENT_TAG with saved IMAGE_TAG
+[[ ${CURRENT_TAG} == ${IMAGE_TAG} ]] || {
+	echo "Updating old TAG ${IMAGE_TAG} with new TAG ${CURRENT_TAG}"
+	sed -i "/IMAGE_TAG/s/=.*$/=${CURRENT_TAG}/" image_info.sh
+	exit 0
+} 
+
+# Fail otherwise
+exit 1


### PR DESCRIPTION
#### What type of PR is this?
feature
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
It changes entrypoint of packetrusher to permit more execution modes and adds image info automation to automatically build new images from last commits.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
