### PR TITLE
srsran-5g tag update

### DIFF
--- a/docs/open5gs-and-srsran-5g/gnb.yaml
+++ b/docs/open5gs-and-srsran-5g/gnb.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   gnb:
-    image: gradiant/srsran-5g:23_10_1
+    image: gradiant/srsran-5g:24_04
     command: 
       - gnb 
     privileged: true


### PR DESCRIPTION
#### What type of PR is this?

<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:

Updates srsran-5g image tag in the gnb.yaml of the tutorial from 23_10_1 to 24_04