### PR TITLE
No-root

### DIFF
--- a/docs/open5gs-and-srsran-4g-usrp/config/mme.yaml
+++ b/docs/open5gs-and-srsran-4g-usrp/config/mme.yaml
@@ -1,5 +1,6 @@
 logger:
-  file: /opt/open5gs/var/log/open5gs/mme.log
+  file:
+    path: /opt/open5gs/var/log/open5gs/mme.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/docs/open5gs-and-srsran-4g-usrp/epc.yaml
+++ b/docs/open5gs-and-srsran-4g-usrp/epc.yaml
@@ -34,6 +34,7 @@ services:
     restart : on-failure
   upf:
     image: gradiant/open5gs:2.7.1
+    user: root
     command: ["open5gs-upfd"]
     cap_add:
       - all

--- a/docs/open5gs-and-srsran-4g/epc.yaml
+++ b/docs/open5gs-and-srsran-4g/epc.yaml
@@ -32,6 +32,7 @@ services:
     restart : on-failure
   upf:
     image: gradiant/open5gs:2.7.1
+    user: root
     command: ["open5gs-upfd"]
     cap_add:
       - all

--- a/docs/open5gs-and-srsran-5g/config/smf.yaml
+++ b/docs/open5gs-and-srsran-5g/config/smf.yaml
@@ -1,5 +1,6 @@
 logger:
-  file: /opt/open5gs/var/log/open5gs/smf.log
+  file:
+    path: /opt/open5gs/var/log/open5gs/smf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/docs/open5gs-and-srsran-5g/core.yaml
+++ b/docs/open5gs-and-srsran-5g/core.yaml
@@ -69,6 +69,7 @@ services:
     
   upf:
     image: gradiant/open5gs:2.7.1
+    user: root
     command:
       - open5gs-upfd
     cap_add:

--- a/docs/open5gs-and-ueransim/config/smf.yaml
+++ b/docs/open5gs-and-ueransim/config/smf.yaml
@@ -1,5 +1,6 @@
 logger:
-  file: /opt/open5gs/var/log/open5gs/smf.log
+  file:
+    path: /opt/open5gs/var/log/open5gs/smf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/docs/open5gs-and-ueransim/ngc.yaml
+++ b/docs/open5gs-and-ueransim/ngc.yaml
@@ -74,6 +74,7 @@ services:
 
   upf:
     image: gradiant/open5gs:2.7.1
+    user: root
     command:
     - open5gs-upfd
     cap_add:

--- a/images/open5gs/Dockerfile
+++ b/images/open5gs/Dockerfile
@@ -103,9 +103,9 @@ WORKDIR ${APP_ROOT}
 COPY entrypoint.sh /entrypoint.sh
 
 # TODO: run with non-root user
-#RUN groupadd -r open5gs && useradd --no-log-init -r -g open5gs open5gs
-#RUN chown -R open5gs:open5gs ${APP_ROOT}
-#USER open5gs
+RUN groupadd -r open5gs && useradd --no-log-init -r -g open5gs open5gs
+RUN chown -R open5gs:open5gs ${APP_ROOT}
+USER open5gs
 
 #Default CONF values
 ENV DB_URI=mongodb://mongo/open5gs

--- a/images/open5gs/Dockerfile
+++ b/images/open5gs/Dockerfile
@@ -102,7 +102,7 @@ ENV PATH=${APP_ROOT}/bin:${PATH} HOME=${APP_ROOT}
 WORKDIR ${APP_ROOT}
 COPY entrypoint.sh /entrypoint.sh
 
-# TODO: run with non-root user
+#Run with non-root user
 RUN groupadd -r open5gs && useradd --no-log-init -r -g open5gs open5gs
 RUN chown -R open5gs:open5gs ${APP_ROOT}
 USER open5gs


### PR DESCRIPTION
#### What type of PR is this?
Feature
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
It creates an open5gs image of the version 2.7.1 that doesn't need to use root in the network functions (but it is needed for the upf).
The docs were modified to use user: root in the container of the upf.

Some outdated configurations were updated to match the new format definition of the logger path.