### PR TITLE
fixes the update_current_tag script so that it does not use docker

### DIFF
--- a/images/openvpn/update_current_tag.sh
+++ b/images/openvpn/update_current_tag.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-CURRENT_TAG=$(docker run --pull=always -ti --rm alpine:latest apk info --no-cache openvpn | grep -Po '(?<=openvpn-)[\d\.]+' | head -1)
+CURRENT_TAG=$(curl -sSL https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/ | grep "openvpn" | awk 'NR==2' | awk -F'[-]' '{print $2}')
 
 # Load IMAGE_TAG
 [[ -f image_info.sh ]] && source image_info.sh || exit 1


### PR DESCRIPTION
#### What type of PR is this?
bug
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
With github actions, Docker does not work as expected, so we change the method to use curl and the official repository of openvpn in Alpine

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
