### PR TITLE
Fix FromAsCasing warning for AS keyword

### DIFF
--- a/images/free5gc-webconsole/Dockerfile
+++ b/images/free5gc-webconsole/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.8 as builder
+FROM golang:1.17.8 AS builder
 
 ARG version=1.0.1
 ENV VERSION=$version

--- a/images/free5gc/Dockerfile
+++ b/images/free5gc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.14 AS builder
 
 ARG version=3.0.6
 ENV VERSION=$version

--- a/images/open5gs/Dockerfile
+++ b/images/open5gs/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye as builder
+FROM debian:bullseye AS builder
 
 ARG version
 ARG branch=main

--- a/images/open5gs/Dockerfile.riscv-unstable
+++ b/images/open5gs/Dockerfile.riscv-unstable
@@ -1,4 +1,4 @@
-FROM debian:unstable as builder
+FROM debian:unstable AS builder
 
 ARG version
 ARG branch=main

--- a/images/packetrusher/Dockerfile
+++ b/images/packetrusher/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal as builder
+FROM ubuntu:focal AS builder
 
 RUN apt-get update && apt install wget git make -y
 

--- a/images/rt-tests/Dockerfile
+++ b/images/rt-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as builder
+FROM ubuntu:22.04 AS builder
 
 ARG version=2.4
 ENV VERSION=$version

--- a/images/srsran-4g/Dockerfile
+++ b/images/srsran-4g/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as builder
+FROM ubuntu:20.04 AS builder
 
 ARG version
 ENV VERSION=$version


### PR DESCRIPTION
#### What type of PR is this?

cleanup

<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:

Fix the `FromAsCasing` warning:

```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

example: https://github.com/Gradiant/5g-images/actions/runs/13655243482/job/38221137784


#### Which issue(s) this PR fixes:

No issue.


#### Special notes for your reviewer:

Probably not the reason that the job failed.


#### Does this PR introduce a user-facing change?

No


#### Does this PR introduce new external dependencies?

No


#### Additional documentation:

No

