### PR TITLE
open5gs: add iperf binary to final container

### DIFF
--- a/images/open5gs/Dockerfile
+++ b/images/open5gs/Dockerfile
@@ -91,7 +91,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     libcurl4 \
     libmicrohttpd12 \
     libnghttp2-14 \
-    wondershaper iproute2 iputils-ping procps net-tools iptables iperf3 traceroute tcpdump && \
+    wondershaper iproute2 iputils-ping procps net-tools iptables iperf iperf3 traceroute tcpdump && \
     rm -rf /var/lib/apt/lists/*
 
 ENV APP_ROOT=/opt/open5gs


### PR DESCRIPTION
#### What type of PR is this?

feature

#### What this PR does / why we need it:

For convenience running simple iperf UDP DL tests is easier with iperf (not iperf3) as there is no server side needed.

When a UE attaches for example we can simply run a `iperf -c 10.45.0.2 -u -b 900M -b t360` to benchmark DL rate.


#### Which issue(s) this PR fixes:

none


#### Special notes for your reviewer:

none

#### Does this PR introduce a user-facing change?

none


#### Does this PR introduce new external dependencies?

no


#### Additional documentation:

```docs

```
